### PR TITLE
feat: allow submission of external themes via URL

### DIFF
--- a/src/routes/submit/+page.server.ts
+++ b/src/routes/submit/+page.server.ts
@@ -14,7 +14,7 @@ export const load: PageServerLoad = (event) => {
 
   if (param) {
     return {
-      halloyUrl: `halloy:///theme?e=${param}`,
+      themeUrl: `halloy:///theme?e=${param}`,
     }
   }
 }
@@ -23,7 +23,7 @@ export const actions: Actions = {
   default: async ({ request }) => {
     const formData = await request.formData();
     const themeName = formData.get('themeName')?.toString();
-    const themeUrl = formData.get('halloyUrl')?.toString();
+    const themeUrl = formData.get('themeUrl')?.toString();
 
     if (!themeName) {
       return fail(400, { error: 'Missing theme name' });
@@ -43,16 +43,18 @@ export const actions: Actions = {
         }
 
         colors = decode(encoded);
-       } else if (themeUrl.endsWith('.toml')) { // External URL with TOML file
-          const response = await fetch(themeUrl);
+      } else if (themeUrl.endsWith('.toml')) { // External URL with TOML file
+        const response = await fetch(themeUrl);
 
-          if (!response.ok) {
-            return fail(400, { error: 'Failed to fetch theme from URL' });
-          }
+        if (!response.ok) {
+          return fail(400, { error: 'Failed to fetch theme from URL' });
+        }
 
-          const tomlString = await response.text();
-          colors = TOML.parse(tomlString);
-       }
+        const tomlString = await response.text();
+        colors = TOML.parse(tomlString);
+      } else {
+        return fail(400, { invalid: true });
+      }
     } catch (e) {
       return fail(400, { invalid: true });
     }

--- a/src/routes/submit/+page.server.ts
+++ b/src/routes/submit/+page.server.ts
@@ -1,3 +1,5 @@
+import * as TOML from '@iarna/toml';
+
 import type { Actions } from './$types';
 
 import { decode } from 'theme';
@@ -21,25 +23,36 @@ export const actions: Actions = {
   default: async ({ request }) => {
     const formData = await request.formData();
     const themeName = formData.get('themeName')?.toString();
-    const halloyUrl = formData.get('halloyUrl')?.toString();
+    const themeUrl = formData.get('halloyUrl')?.toString();
 
     if (!themeName) {
       return fail(400, { error: 'Missing theme name' });
     }
-    if (!halloyUrl) {
-      return fail(400, { error: 'Missing halloy url' });
+    if (!themeUrl) {
+      return fail(400, { error: 'Missing theme url' });
     }
 
     let encoded;
     let colors;
     try {
-      encoded = new URL(halloyUrl).searchParams.get('e');
+      if (themeUrl.startsWith('halloy:///theme')) { // Halloy URL with encoded colors
+        encoded = new URL(themeUrl).searchParams.get('e');
 
-      if (!encoded) {
-        return fail(400, { invalid: true });
-      }
+        if (!encoded) {
+          return fail(400, { invalid: true });
+        }
 
-      colors = decode(encoded);
+        colors = decode(encoded);
+       } else if (themeUrl.endsWith('.toml')) { // External URL with TOML file
+          const response = await fetch(themeUrl);
+
+          if (!response.ok) {
+            return fail(400, { error: 'Failed to fetch theme from URL' });
+          }
+
+          const tomlString = await response.text();
+          colors = TOML.parse(tomlString);
+       }
     } catch (e) {
       return fail(400, { invalid: true });
     }

--- a/src/routes/submit/+page.svelte
+++ b/src/routes/submit/+page.svelte
@@ -6,6 +6,7 @@
   let { form, data }: PageProps = $props();
   let themeName: string = $state('');
   let halloyUrl: string = $state(data.halloyUrl ?? '');
+  let loading: boolean =  $state(false);
 
   $effect(() => {
     if (form?.success) {
@@ -22,12 +23,13 @@
         className: 'mt-4'
       });
     }
+    loading = false;
   });
 </script>
 
 <div class="flex justify-center px-6">
   <div class="w-full max-w-xl pt-16">
-    <form use:enhance method="POST" class="space-y-6">
+    <form use:enhance={() => { loading = true; }} method="POST" class="space-y-6">
       <div>
         <p>Share your favorite theme with our community!</p>
         <p class="text-white/40">
@@ -59,10 +61,14 @@
 
       <button
         type="submit"
-        disabled={!halloyUrl || !themeName}
+        disabled={!halloyUrl || !themeName || loading}
         class="flex w-full cursor-pointer justify-center rounded-md bg-[#50a9d9] px-4 py-2 font-bold text-white shadow-sm transition-colors hover:bg-[#3b92c2] disabled:cursor-not-allowed disabled:bg-[#a1cde4] disabled:text-black/40"
       >
-        Submit
+        {#if loading}
+          <span>Submitting...</span>
+        {:else}
+          Submit
+        {/if}
       </button>
     </form>
   </div>

--- a/src/routes/submit/+page.svelte
+++ b/src/routes/submit/+page.svelte
@@ -6,7 +6,7 @@
   let { form, data }: PageProps = $props();
   let themeName: string = $state('');
   let themeUrl: string = $state(data.themeUrl ?? '');
-  let loading: boolean =  $state(false);
+  let loading: boolean = $state(false);
 
   $effect(() => {
     if (form?.success) {
@@ -29,12 +29,19 @@
 
 <div class="flex justify-center px-6">
   <div class="w-full max-w-xl pt-16">
-    <form use:enhance={() => { loading = true; }} method="POST" class="space-y-6">
+    <form
+      use:enhance={() => {
+        loading = true;
+      }}
+      method="POST"
+      class="space-y-6"
+    >
       <div>
         <p>Share your favorite theme with our community!</p>
         <p class="text-white/40">
           Copy the encoded theme URL from Halloy's Theme Editor or provide the URL to a TOML file.
-          Once submitted, your theme will be reviewed and approved by a maintainer before being listed on the site.
+          Once submitted, your theme will be reviewed and approved by a maintainer before being
+          listed on the site.
         </p>
       </div>
 
@@ -49,7 +56,7 @@
           bind:value={themeName}
         />
         <div class="mb-1 flex flex-row items-center justify-between">
-          <p>Theme URL</p>
+          <p>URL</p>
         </div>
         <input
           class="mb-2 h-10 w-full rounded-lg border border-gray-500/40 px-2 placeholder-white/25 focus:outline-none"

--- a/src/routes/submit/+page.svelte
+++ b/src/routes/submit/+page.svelte
@@ -31,8 +31,8 @@
       <div>
         <p>Share your favorite theme with our community!</p>
         <p class="text-white/40">
-          Copy the encoded theme URL string from Halloy's Theme Editor. Once submitted, your theme
-          will be reviewed and approved by a maintainer before being listed on the site.
+          Copy the encoded theme URL from Halloy's Theme Editor or provide the URL to a TOML file.
+          Once submitted, your theme will be reviewed and approved by a maintainer before being listed on the site.
         </p>
       </div>
 

--- a/src/routes/submit/+page.svelte
+++ b/src/routes/submit/+page.svelte
@@ -5,7 +5,7 @@
 
   let { form, data }: PageProps = $props();
   let themeName: string = $state('');
-  let halloyUrl: string = $state(data.halloyUrl ?? '');
+  let themeUrl: string = $state(data.themeUrl ?? '');
   let loading: boolean =  $state(false);
 
   $effect(() => {
@@ -14,7 +14,7 @@
         className: 'mt-4'
       });
     } else if (form?.invalid) {
-      halloyUrl = '';
+      themeUrl = '';
       toast.error('Failed to decode theme. Ensure it is valid and try again.', {
         className: 'mt-4'
       });
@@ -54,14 +54,14 @@
         <input
           class="mb-2 h-10 w-full rounded-lg border border-gray-500/40 px-2 placeholder-white/25 focus:outline-none"
           placeholder="halloy:///theme?e=ACspLf8BT0dN_wIyMDT_A_-gev8E_s2y..."
-          name="halloyUrl"
-          bind:value={halloyUrl}
+          name="themeUrl"
+          bind:value={themeUrl}
         />
       </div>
 
       <button
         type="submit"
-        disabled={!halloyUrl || !themeName || loading}
+        disabled={!themeUrl || !themeName || loading}
         class="flex w-full cursor-pointer justify-center rounded-md bg-[#50a9d9] px-4 py-2 font-bold text-white shadow-sm transition-colors hover:bg-[#3b92c2] disabled:cursor-not-allowed disabled:bg-[#a1cde4] disabled:text-black/40"
       >
         {#if loading}


### PR DESCRIPTION
Adds support for submitting external TOML theme files via URL to Halloy's theme library.
Users can now submit themes via a link to an externally hosted theme (e.g., GitHub raw URLs, CDNs) as well as from Halloy's encoded URL from the theme editor. This feature will allow externally hosted themes to be in sync with Halloy's theme library.

**Changes on theme submissions:** 
- [x] Validation for theme URLs
- [x] File fetching for external themes 
- [x] TOML parsing for external themes 
- [x] Variable renaming `halloyUrl -> themeUrl`
- [x] Submit button disabled while submitting form, to avoid resubmission while fetching theme
- [x] Copy explaining new feature

Since the colors are stored directly on the database, no further schema changes were necessary. :+1: :+1:

**Testing**
- [x] Verified with Halloy's encoded urls (Previous functionality)
- [x] Verified with valid TOML URLs (GitHub raw, personal servers).
- [x] Tested edge cases (invalid URLs, non-TOML files etc).

**Preview:**

https://github.com/user-attachments/assets/af973d7e-a701-49e7-8489-6b80e4986708


Enables resolution of https://github.com/squidowl/halloy-themes/issues/7 :saluting_face:
